### PR TITLE
[CARE-104] User Service 1차 API 개발 및 User Service 관련 Gateway 수정

### DIFF
--- a/CARING-Back-Gateway/src/main/resources/application.yml
+++ b/CARING-Back-Gateway/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /${segment}
 
-        - id: user-service-manager
+        - id: user-service-auth
           uri: lb://USER-SERVICE
           predicates:
             - Path=/user-service/v1/api/users/**, /user-service/v1/api/managers/**, /user-service/v1/api/shelters/**
@@ -32,7 +32,7 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /${segment}
-            - ManagerAuthorizationHeaderFilter
+            - UserAuthorizationHeaderFilter
 
         ### <ACTUATOR> ###
         - id: user-service-actuator
@@ -77,14 +77,24 @@ spring:
             - RemoveRequestHeader=Cookie
             - RewritePath=/manager-service/(?<segment>.*), /${segment}
 
-        - id: manager-service-api
+        - id: manager-service-access
           uri: lb://MANAGER-SERVICE
           predicates:
-            - Path=/manager-service/v1/api/managers/**, /manager-service/v1/api/submissions/**
+            - Path=Path=/manager-service/v1/api/access/**
             - Method=GET,POST,PUT,DELETE
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/manager-service/(?<segment>.*), /${segment}
+
+        - id: manager-service-auth
+          uri: lb://MANAGER-SERVICE
+          predicates:
+            - Path=/manager-service/v1/api/managers/**, /manager-service/v1/api/shelters/**
+            - Method=GET,POST,PUT,DELETE
+          filters:
+            - RemoveRequestHeader=Cookie
+            - RewritePath=/user-service/(?<segment>.*), /${segment}
+            - ManagerAuthorizationHeaderFilter
 
         - id: manager-service-actuator
           uri: lb://MANAGER-SERVICE

--- a/CARING-Back-User/src/main/java/com/caring/user_service/common/config/SecurityConfig.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/common/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -65,10 +64,14 @@ public class SecurityConfig {
                             .requestMatchers(permitAllRequest()).permitAll()
                             .requestMatchers(additionalSwaggerRequests()).permitAll()
                             .anyRequest().access((authentication, request) -> {
-                                String clientIp = request.getRequest().getRemoteAddr();
+                                String clientIp = request.getRequest().getRemoteHost();
                                 String gatewayIp = microServiceIpResolver.resolveGatewayIp();
-                                log.info("client ip is = {}", clientIp);
+                                log.info("client ip is = {} gateway ip is = {}", clientIp, gatewayIp);
                                 boolean isAllowed = clientIp.equals(gatewayIp);
+                                // TODO: 보안 설정에서 localhost(127.0.0.1) 허용은 개발 환경에만 적용해야함
+                                if(clientIp.equals("127.0.0.1")) {
+                                    isAllowed = true;
+                                }
 
                                 return new AuthorizationDecision(isAllowed);
                             });

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/adaptor/UserAdaptor.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/adaptor/UserAdaptor.java
@@ -15,4 +15,6 @@ public interface UserAdaptor {
     User queryUserByUserUuid(String userUuid);
 
     List<User> queryByUserUuidList(List<String> userUuidList);
+
+    User queryUserByNameAndBirthDateAndPhoneNumber(String name, String birthDate, String phoneNumber);
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/adaptor/UserAdaptorImpl.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/adaptor/UserAdaptorImpl.java
@@ -49,4 +49,12 @@ public class UserAdaptorImpl implements UserAdaptor{
     public List<User> queryByUserUuidList(List<String> userUuidList) {
         return userRepository.findByUserUuidIn(userUuidList);
     }
+
+    @Override
+    public User queryUserByNameAndBirthDateAndPhoneNumber(String name, String birthDate, String phoneNumber) {
+        return userRepository.findByNameAndBirthDateAndPhoneNumber(name, birthDate, phoneNumber)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "User not found with name: " + name + " and birthDate: " + birthDate +
+                                " and phoneNumber: " + phoneNumber));
+    }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/EmergencyContactDomainService.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/EmergencyContactDomainService.java
@@ -1,0 +1,8 @@
+package com.caring.user_service.domain.user.business.domainservice;
+
+import com.caring.user_service.domain.user.entity.User;
+
+public interface EmergencyContactDomainService {
+
+    void addEmergencyContact(User user, String name, String relationship, String phoneNumber);
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/EmergencyContactDomainServiceImpl.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/EmergencyContactDomainServiceImpl.java
@@ -1,0 +1,26 @@
+package com.caring.user_service.domain.user.business.domainservice;
+
+import com.caring.user_service.common.annotation.DomainService;
+import com.caring.user_service.domain.user.entity.EmergencyContact;
+import com.caring.user_service.domain.user.entity.User;
+import com.caring.user_service.domain.user.repository.EmergencyContactRepository;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class EmergencyContactDomainServiceImpl implements EmergencyContactDomainService {
+
+    private final EmergencyContactRepository emergencyContactRepository;
+
+    @Override
+    public void addEmergencyContact(User user, String name, String relationship, String phoneNumber) {
+        EmergencyContact contact = EmergencyContact.builder()
+                .user(user)
+                .contactName(name)
+                .contactRelationship(relationship)
+                .contactPhoneNumber(phoneNumber)
+                .build();
+
+        emergencyContactRepository.save(contact);
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/UserDomainService.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/UserDomainService.java
@@ -7,4 +7,6 @@ public interface UserDomainService {
     User registerUser(String name, String password);
 
     User registerUserWithShelterUuid(String name, String password, String shelterUuid);
+
+    void resetPassword(User user, String encodedPassword);
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/UserDomainServiceImpl.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/business/domainservice/UserDomainServiceImpl.java
@@ -51,4 +51,12 @@ public class UserDomainServiceImpl implements UserDomainService {
                 .build();
         return userRepository.save(newUser);
     }
+
+    @Override
+    public void resetPassword(User user, String encodedPassword) {
+        if (user.isSamePassword(encodedPassword)) {
+            throw new IllegalArgumentException("이전에 사용한 비밀번호와 동일합니다.");
+        }
+        user.changePassword(encodedPassword);
+    }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/EmergencyContact.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/EmergencyContact.java
@@ -1,0 +1,44 @@
+package com.caring.user_service.domain.user.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "user_emergency_contacts")
+public class EmergencyContact {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "contact_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // 외래 키
+    private User user;
+
+    @Column(name = "contact_name", nullable = false)
+    private String contactName;
+
+    @Column(name = "contact_relationship")
+    private String contactRelationship;
+
+    @Column(name = "contact_phone_number", nullable = false)
+    private String contactPhoneNumber;
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/User.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/User.java
@@ -1,15 +1,30 @@
 package com.caring.user_service.domain.user.entity;
 
 import com.caring.user_service.domain.auditing.entity.BaseTimeEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 @Entity
 @Getter
@@ -36,6 +51,27 @@ public class User extends BaseTimeEntity implements UserDetails {
     private String name;
     @Column(name = "shelter_uuid")
     private String shelterUuid;
+
+    @Column(name = "birth_date")
+    private String birthDate; // ex: 19980505 (String)
+
+    @Column(name = "phone_number", length = 20)
+    private String phoneNumber;
+
+    @Column(name = "road_address") // 도로명 주소
+    private String roadAddress;
+
+    @Column(name = "detail_address") // 상세 주소
+    private String detailAddress;
+
+    @Column(name = "postal_code", length = 10) // 우편번호
+    private String postalCode;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<EmergencyContact> emergencyContacts = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/User.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/entity/User.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -85,5 +86,13 @@ public class User extends BaseTimeEntity implements UserDetails {
 
     public void groupedInShelter(String shelterUuid) {
         this.shelterUuid = shelterUuid;
+    }
+
+    public boolean isSamePassword(String encodedPassword) {
+        return Objects.equals(this.password, encodedPassword);
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/repository/EmergencyContactRepository.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/repository/EmergencyContactRepository.java
@@ -1,0 +1,7 @@
+package com.caring.user_service.domain.user.repository;
+
+import com.caring.user_service.domain.user.entity.EmergencyContact;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmergencyContactRepository extends JpaRepository<EmergencyContact, Long> {
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/repository/UserRepository.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/domain/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserUuid(String userUuid);
 
     List<User> findByUserUuidIn(List<String> userUuids);
+
+    Optional<User> findByNameAndBirthDateAndPhoneNumber(String name, String birthDate, String phoneNumber);
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserAccessApiController.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserAccessApiController.java
@@ -3,13 +3,17 @@ package com.caring.user_service.presentation.user.controller;
 import com.caring.user_service.presentation.user.service.FindMyMemberCodeUseCase;
 import com.caring.user_service.presentation.user.service.ReadAllUserUseCase;
 import com.caring.user_service.presentation.user.service.RegisterUserUseCase;
+import com.caring.user_service.presentation.user.service.ResetUserPasswordUseCase;
 import com.caring.user_service.presentation.user.vo.RequestMemberCode;
+import com.caring.user_service.presentation.user.vo.RequestResetPassword;
 import com.caring.user_service.presentation.user.vo.RequestUser;
 import com.caring.user_service.presentation.user.vo.ResponseMemberCode;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +31,7 @@ public class UserAccessApiController {
     private final RegisterUserUseCase registerUserUseCase;
     private final ReadAllUserUseCase readAllUserUseCase;
     private final FindMyMemberCodeUseCase findMyMemberCodeUseCase;
+    private final ResetUserPasswordUseCase resetUserPasswordUseCase;
 
     @Operation(summary = "새로운 유저를 등록합니다.")
     @PostMapping("/register")
@@ -44,5 +49,12 @@ public class UserAccessApiController {
     @Operation(summary = "핸드폰 인증을 통해 내 memberCode를 조회합니다.")
     public ResponseMemberCode findMyMemberCode(@RequestBody RequestMemberCode request) {
         return findMyMemberCodeUseCase.execute(request);
+    }
+
+    @PostMapping("/my/reset-password")
+    @Operation(summary = "비밀번호 재설정 (휴대폰 인증 완료 후)")
+    public ResponseEntity<Void> resetPassword(@RequestBody @Valid RequestResetPassword request) {
+        resetUserPasswordUseCase.execute(request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserAccessApiController.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserAccessApiController.java
@@ -1,8 +1,11 @@
 package com.caring.user_service.presentation.user.controller;
 
+import com.caring.user_service.presentation.user.service.FindMyMemberCodeUseCase;
 import com.caring.user_service.presentation.user.service.ReadAllUserUseCase;
 import com.caring.user_service.presentation.user.service.RegisterUserUseCase;
+import com.caring.user_service.presentation.user.vo.RequestMemberCode;
 import com.caring.user_service.presentation.user.vo.RequestUser;
+import com.caring.user_service.presentation.user.vo.ResponseMemberCode;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +26,7 @@ public class UserAccessApiController {
 
     private final RegisterUserUseCase registerUserUseCase;
     private final ReadAllUserUseCase readAllUserUseCase;
+    private final FindMyMemberCodeUseCase findMyMemberCodeUseCase;
 
     @Operation(summary = "새로운 유저를 등록합니다.")
     @PostMapping("/register")
@@ -34,5 +38,11 @@ public class UserAccessApiController {
     @GetMapping
     public List<ResponseUser> getAllUser() {
         return readAllUserUseCase.execute();
+    }
+
+    @PostMapping("/my/member-code")
+    @Operation(summary = "핸드폰 인증을 통해 내 memberCode를 조회합니다.")
+    public ResponseMemberCode findMyMemberCode(@RequestBody RequestMemberCode request) {
+        return findMyMemberCodeUseCase.execute(request);
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
@@ -68,4 +68,11 @@ public class UserApiController {
     public ResponseUserShelterUuid getUserShelterUuid(@PathVariable String userUuid) {
         return getUserShelterUuidUseCase.execute(userUuid);
     }
+
+    @Operation(summary = "유저가 비상연락망 직접 추가 beta (관리자가 추가 하는건 권한 문제 해결후 처리예정)")
+    @PostMapping("/emergency-contacts")
+    public ResponseEntity<Void> saveEmergencyContacts (@RequestBody RequestEmergencyContact request) {
+        addEmergencyContactsUseCase.execute(request);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
@@ -1,6 +1,5 @@
 package com.caring.user_service.presentation.user.controller;
 
-import com.caring.user_service.common.annotation.ManagerCode;
 import com.caring.user_service.presentation.user.service.GetUserProfileUseCase;
 import com.caring.user_service.presentation.user.service.GetUserShelterUuidUseCase;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
@@ -11,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,16 +25,28 @@ public class UserApiController {
     private final GetUserShelterUuidUseCase getUserShelterUuidUseCase;
 
     @Operation(summary = "특정 유저의 계정을 조회합니다.")
-    @GetMapping("/{userUuid}")
-    public ResponseUser getUserProfile(@PathVariable String userUuid,
-            @ManagerCode String managerCode) {
-        return getUserProfileUseCase.execute(userUuid);
+    @GetMapping("/{memberCode}")
+    public ResponseUser getUserProfile(@PathVariable String memberCode) {
+        return getUserProfileUseCase.execute(memberCode);
     }
+
+    @Operation(
+            summary = "내 정보를 조회합니다. (홈 화면 X)",
+            description = """
+                    프론트엔드는 Authorization 헤더(JWT)만 전송하면 됩니다.
+                    Gateway에서 JWT를 파싱하여 자동으로 'member-code' 헤더를 추가하므로,
+                    'member-code' 헤더는 프론트에서 명시적으로 포함시킬 필요가 없습니다.
+                     포스트맨에서 테스트 가능합니다.""")
+    @GetMapping("/my/info")
+    public ResponseUser getMyInfo(@RequestHeader("member-code") String memberCode) {
+        return getUserProfileUseCase.execute(memberCode);
+    }
+
+
 
     @Operation(summary = "특정 유저의 shelterUuid를 반환합니다. 유저가 없으면 404를 반환합니다.")
     @GetMapping("/{userUuid}/shelterUuid")
-    public ResponseUserShelterUuid getUserShelterUuid(@PathVariable String userUuid,
-            @ManagerCode String managerCode) {
+    public ResponseUserShelterUuid getUserShelterUuid(@PathVariable String userUuid) {
         return getUserShelterUuidUseCase.execute(userUuid);
     }
 

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
@@ -1,15 +1,22 @@
 package com.caring.user_service.presentation.user.controller;
 
+import com.caring.user_service.presentation.user.service.AddEmergencyContactsUseCase;
+import com.caring.user_service.presentation.user.service.GetUserHomeInfoUseCase;
 import com.caring.user_service.presentation.user.service.GetUserProfileUseCase;
 import com.caring.user_service.presentation.user.service.GetUserShelterUuidUseCase;
+import com.caring.user_service.presentation.user.vo.RequestEmergencyContact;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
+import com.caring.user_service.presentation.user.vo.ResponseUserHomeInfo;
 import com.caring.user_service.presentation.user.vo.ResponseUserShelterUuid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +30,8 @@ public class UserApiController {
 
     private final GetUserProfileUseCase getUserProfileUseCase;
     private final GetUserShelterUuidUseCase getUserShelterUuidUseCase;
+    private final GetUserHomeInfoUseCase getUserHomeInfoUseCase;
+    private final AddEmergencyContactsUseCase addEmergencyContactsUseCase;
 
     @Operation(summary = "특정 유저의 계정을 조회합니다.")
     @GetMapping("/{memberCode}")
@@ -42,12 +51,21 @@ public class UserApiController {
         return getUserProfileUseCase.execute(memberCode);
     }
 
-
+    @Operation(
+            summary = "경량화된 내 정보(비상연락망 포함x)를 조회합니다. (홈 화면 O)",
+            description = """
+                    프론트엔드는 Authorization 헤더(JWT)만 전송하면 됩니다.
+                    Gateway에서 JWT를 파싱하여 자동으로 'member-code' 헤더를 추가하므로,
+                    'member-code' 헤더는 프론트에서 명시적으로 포함시킬 필요가 없습니다.
+                     포스트맨에서 테스트 가능합니다.""")
+    @GetMapping("home/info")
+    public ResponseUserHomeInfo getHomeInfo(@RequestHeader("member-code") String memberCode) {
+        return getUserHomeInfoUseCase.execute(memberCode);
+    }
 
     @Operation(summary = "특정 유저의 shelterUuid를 반환합니다. 유저가 없으면 404를 반환합니다.")
     @GetMapping("/{userUuid}/shelterUuid")
     public ResponseUserShelterUuid getUserShelterUuid(@PathVariable String userUuid) {
         return getUserShelterUuidUseCase.execute(userUuid);
     }
-
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/EmergencyContactMapper.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/EmergencyContactMapper.java
@@ -1,0 +1,16 @@
+package com.caring.user_service.presentation.user.mapper;
+
+import com.caring.user_service.domain.user.entity.EmergencyContact;
+import com.caring.user_service.presentation.user.vo.ResponseEmergencyContact;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+public interface EmergencyContactMapper {
+
+    ResponseEmergencyContact toResponse(EmergencyContact contact);
+
+    List<ResponseEmergencyContact> toResponseList(List<EmergencyContact> contacts);
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.caring.user_service.presentation.user.mapper;
 
 import com.caring.user_service.domain.user.entity.User;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
+import com.caring.user_service.presentation.user.vo.ResponseUserHomeInfo;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
 
@@ -15,5 +16,7 @@ public interface UserMapper {
 //    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
     ResponseUser toResponseUserVo(User user);
+
+    ResponseUserHomeInfo toResponseUserHomeInfoVo(User user);
 
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
@@ -4,7 +4,6 @@ import com.caring.user_service.domain.user.entity.User;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
 import org.mapstruct.Builder;
 import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
 
 /**
  * vo는 setter를 쓰지 않기 때문에 impl생성이 자동으로 builder가 될 수 있도록 아래와 같이 설정해줘야한다.

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/mapper/UserMapper.java
@@ -10,10 +10,10 @@ import org.mapstruct.factory.Mappers;
  * vo는 setter를 쓰지 않기 때문에 impl생성이 자동으로 builder가 될 수 있도록 아래와 같이 설정해줘야한다.
  * 이때 build.gradle의 순서가 중요하니 주의
  */
-@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false))
+@Mapper(componentModel = "spring", builder = @Builder(disableBuilder = false), uses={ EmergencyContactMapper.class })
 public interface UserMapper {
 
-    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+//    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
     ResponseUser toResponseUserVo(User user);
 

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/AddEmergencyContactsUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/AddEmergencyContactsUseCase.java
@@ -1,0 +1,25 @@
+package com.caring.user_service.presentation.user.service;
+
+import com.caring.user_service.common.annotation.UseCase;
+import com.caring.user_service.domain.user.business.adaptor.UserAdaptor;
+import com.caring.user_service.domain.user.business.domainservice.EmergencyContactDomainService;
+import com.caring.user_service.domain.user.entity.User;
+import com.caring.user_service.presentation.user.vo.RequestEmergencyContact;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class AddEmergencyContactsUseCase {
+
+    private final UserAdaptor userAdaptor;
+    private final EmergencyContactDomainService emergencyContactDomainService;
+
+    public void execute(RequestEmergencyContact request) {
+        User user = userAdaptor.queryUserByMemberCode(request.getMemberCode());
+
+        emergencyContactDomainService.addEmergencyContact(user, request.getContactName(),
+                request.getContactRelationship(), request.getContactPhoneNumber());
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
@@ -1,0 +1,23 @@
+package com.caring.user_service.presentation.user.service;
+
+import com.caring.user_service.domain.user.business.adaptor.UserAdaptor;
+import com.caring.user_service.domain.user.entity.User;
+import com.caring.user_service.presentation.user.vo.RequestMemberCode;
+import com.caring.user_service.presentation.user.vo.ResponseMemberCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FindMyMemberCodeUseCase {
+
+    private final UserAdaptor userAdaptor;
+
+    public ResponseMemberCode execute(RequestMemberCode request) {
+
+        User user = userAdaptor.queryUserByNameAndBirthDateAndPhoneNumber(request.getName(),
+                request.getBirthDate(), request.getPhoneNumber());
+
+        return new ResponseMemberCode(user.getMemberCode());
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
@@ -18,6 +18,6 @@ public class FindMyMemberCodeUseCase {
         User user = userAdaptor.queryUserByNameAndBirthDateAndPhoneNumber(request.getName(),
                 request.getBirthDate(), request.getPhoneNumber());
 
-        return new ResponseMemberCode(user.getMemberCode());
+        return new ResponseMemberCode(user.getName(), user.getMemberCode());
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/FindMyMemberCodeUseCase.java
@@ -1,5 +1,6 @@
 package com.caring.user_service.presentation.user.service;
 
+import com.caring.user_service.common.annotation.UseCase;
 import com.caring.user_service.domain.user.business.adaptor.UserAdaptor;
 import com.caring.user_service.domain.user.entity.User;
 import com.caring.user_service.presentation.user.vo.RequestMemberCode;
@@ -7,6 +8,7 @@ import com.caring.user_service.presentation.user.vo.ResponseMemberCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+@UseCase
 @Service
 @RequiredArgsConstructor
 public class FindMyMemberCodeUseCase {

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUserHomeInfoUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUserHomeInfoUseCase.java
@@ -1,0 +1,24 @@
+package com.caring.user_service.presentation.user.service;
+
+import com.caring.user_service.common.annotation.UseCase;
+import com.caring.user_service.domain.user.business.adaptor.UserAdaptor;
+import com.caring.user_service.domain.user.entity.User;
+import com.caring.user_service.presentation.user.mapper.UserMapper;
+import com.caring.user_service.presentation.user.vo.ResponseUserHomeInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetUserHomeInfoUseCase {
+
+    private final UserAdaptor userAdaptor;
+    private final UserMapper userMapper;
+
+    public ResponseUserHomeInfo execute(String memberCode) {
+        User user = userAdaptor.queryUserByMemberCode(memberCode);
+
+        return userMapper.toResponseUserHomeInfoVo(user);
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUserProfileUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUserProfileUseCase.java
@@ -14,10 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class GetUserProfileUseCase {
 
     private final UserAdaptor userAdaptor;
+    private final UserMapper userMapper;
 
-    public ResponseUser execute(String userUuid) {
-        User user = userAdaptor.queryUserByUserUuid(userUuid);
-        return UserMapper.INSTANCE.toResponseUserVo(user);
+    public ResponseUser execute(String memberCode) {
+        User user = userAdaptor.queryUserByMemberCode(memberCode);
+        return userMapper.toResponseUserVo(user);
     }
 
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUsersByUuidListUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/GetUsersByUuidListUseCase.java
@@ -16,12 +16,13 @@ import java.util.List;
 public class GetUsersByUuidListUseCase {
 
     private final UserAdaptor userAdaptor;
+    private final UserMapper userMapper;
 
     public List<ResponseUser> execute(List<String> uuidList) {
         List<User> users = userAdaptor.queryByUserUuidList(uuidList);
 
         return users.stream()
-                .map(UserMapper.INSTANCE::toResponseUserVo)
+                .map(userMapper::toResponseUserVo)
                 .toList();
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/ReadAllUserUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/ReadAllUserUseCase.java
@@ -16,11 +16,12 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ReadAllUserUseCase {
     private final UserAdaptor userAdaptor;
+    private final UserMapper userMapper;
 
     public List<ResponseUser> execute() {
         List<User> users = userAdaptor.queryAll();
         return users.stream()
-                .map(user -> UserMapper.INSTANCE.toResponseUserVo(user))
+                .map(userMapper::toResponseUserVo)
                 .collect(Collectors.toList());
     }
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/ResetUserPasswordUseCase.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/service/ResetUserPasswordUseCase.java
@@ -1,0 +1,29 @@
+package com.caring.user_service.presentation.user.service;
+
+import com.caring.user_service.common.annotation.UseCase;
+import com.caring.user_service.domain.user.business.adaptor.UserAdaptor;
+import com.caring.user_service.domain.user.business.domainservice.UserDomainService;
+import com.caring.user_service.domain.user.entity.User;
+import com.caring.user_service.presentation.user.vo.RequestResetPassword;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@UseCase
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ResetUserPasswordUseCase {
+
+    private final UserAdaptor userAdaptor;
+    private final PasswordEncoder passwordEncoder;
+    private final UserDomainService userDomainService;
+
+    public void execute(RequestResetPassword request) {
+        User user = userAdaptor.queryUserByMemberCode(request.getMemberCode());
+        String encodedPassword = passwordEncoder.encode(request.getNewPassword());
+
+        userDomainService.resetPassword(user, encodedPassword);
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestEmergencyContact.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestEmergencyContact.java
@@ -1,0 +1,19 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RequestEmergencyContact {
+
+    private String memberCode; // 유저 memberCode
+    private String contactName;
+    private String contactRelationship;
+    private String contactPhoneNumber;
+}
+

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestMemberCode.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestMemberCode.java
@@ -1,0 +1,14 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RequestMemberCode {
+    private final String name;
+    private final String birthDate;
+    private final String phoneNumber;
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestResetPassword.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/RequestResetPassword.java
@@ -1,0 +1,13 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RequestResetPassword {
+    private final String memberCode;
+    private final String newPassword;
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseEmergencyContact.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseEmergencyContact.java
@@ -1,0 +1,14 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseEmergencyContact {
+    private final String contactName;
+    private final String contactRelationship;
+    private final String contactPhoneNumber;
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseMemberCode.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseMemberCode.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class ResponseMemberCode {
+    private final String name;
     private final String memberCode;
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseMemberCode.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseMemberCode.java
@@ -1,0 +1,12 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseMemberCode {
+    private final String memberCode;
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseUser.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseUser.java
@@ -1,12 +1,20 @@
 package com.caring.user_service.presentation.user.vo;
 
-import lombok.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class ResponseUser {
     private final String name;
-    private final String userUuid;
     private final String memberCode;
+    private final String userUuid;
+    private final String shelterUuid;
+    private final String profileImageUrl;
+    private final List<ResponseEmergencyContact> emergencyContacts;
 }

--- a/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseUserHomeInfo.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/presentation/user/vo/ResponseUserHomeInfo.java
@@ -1,0 +1,15 @@
+package com.caring.user_service.presentation.user.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ResponseUserHomeInfo {
+    private final String name;
+    private final String userUuid;
+    private final String shelterUuid;
+    private final String profileImageUrl;
+}


### PR DESCRIPTION
## 관련 이슈
- #2 

## #️⃣ 요약 설명
- User 테이블 수정 (전화번호, 주소, 생일 추가) 및 EmergencyContact 관련 테이블 추가
- S3 버킷 생성 및 차후 2차 배포 때 이미지 수정 API 추가 예정
- 이슈에 있던 4개의 API + 기존 회원 가입 API 수정 (부족했던 정보 추가) + 비상 연락처 추가 (BETA) API 추가
- 비상 연락처 추가 API에서 권한 관련 논의 필요,,

## 📝 작업 내용

### 1. users 테이블 수정 및 user_emergency_contacts 테이블 추가
![image](https://github.com/user-attachments/assets/886a492f-198b-4b39-94cf-c4a29d1c925b)

### 2. S3 버킷 생성 및 프론트 전용 IAM 유저 배포 예정
![image](https://github.com/user-attachments/assets/c5b13222-3a49-490b-a9d6-67b3873adeb3)
- 현재 Public Bucket으로 생성해두었습니다!
- 회의 때 ec2 가동에 필요한 IAM 계정을 알려드릴 예정입니다!

### 3. 이슈에 있던 4개의 API 생성
- 비밀번호 재설정과, MemberCode 조회는 ACCESS API로 인증 없이 자유롭게 이용 가능합니다.
- ✅ 비밀번호 재설정과 MemberCode 조회에서 핸드폰 본인 인증방식을 어떤 것을 쓰는 지 아직 알지 못하여(nice 본인인증? pass 본인인증?) 레거시한 형태로 만들었습니다. (보안 이슈 있을 수 있음)
- ✅ 내 정보 조회 및 홈 화면에서 경량화된 내 정보 조회는 AUTH API로 User의 Bearer JWT가 필요합니다!
- Swagger에 헷갈릴만한 부분을 추가로 적어두었습니다.
- ⭐ Gateway에서 UserService인데 ManagerAuthorizationHeaderFilter로 필터링되어 Auth API가 정상 작동되지 않아 이 부분 전체적으로 수정하였습니다! 꼭 확인 부탁드립니다!!

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.


```java
//컨트롤러만 발췌하였습니다!
@Tag(name = "[회원(ACCESS)]")
@RequestMapping("/v1/api/access/users")
public class UserAccessApiController {
    @PostMapping("/my/member-code")
    @Operation(summary = "핸드폰 인증을 통해 내 memberCode를 조회합니다.")
    public ResponseMemberCode findMyMemberCode(@RequestBody RequestMemberCode request) {
        return findMyMemberCodeUseCase.execute(request);
    }

    @PostMapping("/my/reset-password")
    @Operation(summary = "비밀번호 재설정 (휴대폰 인증 완료 후)")
    public ResponseEntity<Void> resetPassword(@RequestBody @Valid RequestResetPassword request) {
        resetUserPasswordUseCase.execute(request);
        return ResponseEntity.ok().build();
    }
}

@Tag(name = "[회원(AUTH)]")
@RequestMapping("/v1/api/users")
public class UserApiController {
    @Operation(
            summary = "내 정보를 조회합니다. (홈 화면 X)",
            description = """
                    프론트엔드는 Authorization 헤더(JWT)만 전송하면 됩니다.
                    Gateway에서 JWT를 파싱하여 자동으로 'member-code' 헤더를 추가하므로,
                    'member-code' 헤더는 프론트에서 명시적으로 포함시킬 필요가 없습니다.
                     포스트맨에서 테스트 가능합니다.""")
    @GetMapping("/my/info")
    public ResponseUser getMyInfo(@RequestHeader("member-code") String memberCode) {
        return getUserProfileUseCase.execute(memberCode);
    }

    @Operation(
            summary = "경량화된 내 정보(비상연락망 포함x)를 조회합니다. (홈 화면 O)",
            description = """
                    프론트엔드는 Authorization 헤더(JWT)만 전송하면 됩니다.
                    Gateway에서 JWT를 파싱하여 자동으로 'member-code' 헤더를 추가하므로,
                    'member-code' 헤더는 프론트에서 명시적으로 포함시킬 필요가 없습니다.
                     포스트맨에서 테스트 가능합니다.""")
    @GetMapping("home/info")
    public ResponseUserHomeInfo getHomeInfo(@RequestHeader("member-code") String memberCode) {
        return getUserHomeInfoUseCase.execute(memberCode);
    }


  @Operation(summary = "유저가 비상연락망 직접 추가 beta (관리자가 추가 하는건 권한 문제 해결후 처리예정)")
    @PostMapping("/emergency-contacts")
    public ResponseEntity<Void> saveEmergencyContacts (@RequestBody RequestEmergencyContact request) {
        addEmergencyContactsUseCase.execute(request);
        return ResponseEntity.ok().build();
    }
}
```

## 동작 확인

### 1. 기존 회원 가입 DTO 수정 및 반환 값 userId 대신 user의 memberCode 반환
![image](https://github.com/user-attachments/assets/ac5e6b9a-8545-4402-8448-6a9aabd27f7e)

### 2. 비밀번호 변경 API (전화번호 인증되었다 가정)
![image](https://github.com/user-attachments/assets/aa610255-cc19-4f32-9545-aa740f3a18aa)
- 변경 후 이전 비밀번호 입력시 현재 Internal Error가 나오니 참고 부탁드립니다!

### 3. User의 memberCode를 찾는 API (이 역시 전화번호 인증되었다 가정)
![image](https://github.com/user-attachments/assets/c070e462-2f21-40bc-bfcb-b0c9e9dfd7c1)

### 4. 내 정보 (비상 연락망 있는 창 전용) API (인증 헤더가 반드시 있어야 함)
![image](https://github.com/user-attachments/assets/5c183b78-8503-4fec-86ce-c58c330299cb)
- Swagger에선 헤더로 member-code를 요청하는데 여기서 memberCode를 넣어도 작동합니다! 이건 gateway에서 자동으로 헤더에서 붙이기 때문에, postman에서 인증 헤더만 추가하고 날릴 시 정상적으로 작동합니다!

### 5. 경량화된 내 정보 (홈 화면 전용) API (인증 헤더가 반드시 있어야 함)
![image](https://github.com/user-attachments/assets/d0ae8784-f34c-4d31-9173-40e2fb661928)
- 이 역시 4번 내정보 API와 같은 방식입니다! 다만, 데이터 경량화를 위해 UseCase를 별도로 두어 관리하였습니다.

### 6. 비상 연락망 추가 API (BETA)
![image](https://github.com/user-attachments/assets/2380dab4-ba98-444a-9d18-0a4c52503bec)
- 밑의 리뷰 요구 사항에 추가적으로 의논 사항을 적었습니다! 

> ex) 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> ex) 테스트 코드 작성도 좋습니다!

## 💬 리뷰 요구사항(선택)
### 비상 연락망 추가 API의 위치에 대한 문의 (Access API vs Auth API vs Manager Service -> Internal API)
현재 비상 연락망 추가 API는 유저 서비스의 Auth API 내에 위치해 있습니다. 이 경우, 요청 시 유저의 JWT 토큰이 필요하게 되는데, Manager 서비스에서는 해당 유저의 JWT를 발급할 수 없기 때문에 실제 운영에서는 문제가 될 것 같습니다!

따라서 다음 두 가지 방향을 고민하고 있습니다:

Access API로 이동하여 퍼블릭하게 관리
→ 다만, 다른 악의적인 인증된 유저가 해당 유저의 memberCode를 가진다면 쉽게 비상 연락망을 관리할 수 있습니다...

User 서비스의 Internal API로 구성하여 Manager 서비스에서 호출
→ Manager 서비스에서 자체 인증을 마친 후, 내부 인증 방식으로 User 서비스의 API를 호출
→ 개인적으로 이 방법이 가장 인증까지 고려한 설계인 것 같습니다! Openfeign을 이용한 방향성도 맞고 (Manager -> User), 실제 매니저가 실행하는 시퀀스와 가장 유사하기 때문입니다. 다만 결국 다른 api를 한번 더 거치기 때문에 속도 차원에서 문제가 생길까 고민입니다..

위 두 가지 방안 중 어떤 방식이 더 적절할지, 혹은 더 나은 구조에 대한 정한님의 의견이 궁금합니다. 피드백 부탁드립니다!

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
