### PR TITLE
[CARE-114] 내부 서비스 및 Gateway 요청 인증 헤더 기반 보안 개발

### DIFF
--- a/CARING-Back-Gateway/build.gradle
+++ b/CARING-Back-Gateway/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	// RabbitMQ
 	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
+	//HMAC, Base64 encryption Util
+	implementation 'commons-codec:commons-codec:1.19.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/CARING-Back-Gateway/src/main/java/com/caring/apigateway_service/filter/GlobalFilter.java
+++ b/CARING-Back-Gateway/src/main/java/com/caring/apigateway_service/filter/GlobalFilter.java
@@ -2,18 +2,26 @@ package com.caring.apigateway_service.filter;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
 public class GlobalFilter extends AbstractGatewayFilterFactory<GlobalFilter.Config> {
-    public GlobalFilter(){
+
+    private final Environment env;
+
+    public GlobalFilter(Environment env) {
         super(Config.class);
+        this.env = env;
     }
 
     @Override
@@ -21,12 +29,37 @@ public class GlobalFilter extends AbstractGatewayFilterFactory<GlobalFilter.Conf
         return (exchange, chain) -> {
             ServerHttpRequest request = exchange.getRequest();
             logPreFilter(config, request);
-            log.info("test");
 
-            return chain.filter(exchange)
-                    .doOnError(throwable -> log.error("Error occurred during request processing: {}", throwable.getMessage(), throwable))
+            ServerWebExchange mutatedExchange;
+
+            if (config.isAddGateWaySignature()) {
+                long timestamp = System.currentTimeMillis();
+
+                String gatewaySecret = env.getProperty("token.secret-gateway");
+                if (gatewaySecret == null) {
+                    log.error("token.secret-gateway is not configured in environment");
+                    return chain.filter(exchange); // 혹은 예외 처리
+                }
+
+                String signature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, gatewaySecret)
+                        .hmacHex(String.valueOf(timestamp));
+
+                ServerHttpRequest mutatedRequest = request.mutate()
+                        .header("X-Gateway-Timestamp", String.valueOf(timestamp))
+                        .header("X-Gateway-Signature", signature)
+                        .build();
+
+                mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+            } else {
+                mutatedExchange = exchange;
+            }
+
+            return chain.filter(mutatedExchange)
+                    .doOnError(throwable ->
+                            log.error("Error occurred during request processing: {}", throwable.getMessage(), throwable)
+                    )
                     .then(Mono.fromRunnable(() -> {
-                        ServerHttpResponse response = exchange.getResponse();
+                        ServerHttpResponse response = mutatedExchange.getResponse();
                         logPostFilter(config, response);
                     }));
         };
@@ -49,5 +82,6 @@ public class GlobalFilter extends AbstractGatewayFilterFactory<GlobalFilter.Conf
         private String baseMessage;
         private boolean preLogger;
         private boolean postLogger;
+        private boolean addGateWaySignature;
     }
 }

--- a/CARING-Back-Gateway/src/main/java/com/caring/apigateway_service/filter/InternalAuthorizationHeaderFilter.java
+++ b/CARING-Back-Gateway/src/main/java/com/caring/apigateway_service/filter/InternalAuthorizationHeaderFilter.java
@@ -1,0 +1,92 @@
+package com.caring.apigateway_service.filter;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.security.MessageDigest;
+
+@Slf4j
+@Component
+public class InternalAuthorizationHeaderFilter extends AbstractGatewayFilterFactory<InternalAuthorizationHeaderFilter.Config> {
+
+    private final Environment env;
+
+    public InternalAuthorizationHeaderFilter(Environment environment) {
+        super(Config.class);
+        this.env = environment;
+    }
+
+    private static final String HEADER_SIGNATURE = "X-Internal-Signature";
+    private static final String HEADER_TIMESTAMP = "X-Internal-Timestamp";
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            ServerHttpRequest request = exchange.getRequest();
+            logPreFilter(config, request);
+            String signature = request.getHeaders().getFirst(HEADER_SIGNATURE);
+            String timestampStr = request.getHeaders().getFirst(HEADER_TIMESTAMP);
+
+            if (signature == null || timestampStr == null) {
+                return onError(exchange, "Missing signature or timestamp", HttpStatus.UNAUTHORIZED);
+            }
+
+            long now = System.currentTimeMillis();
+            long timestamp;
+            try {
+                timestamp = Long.parseLong(timestampStr);
+            } catch (NumberFormatException e) {
+                log.warn("Invalid timestamp format: {}", timestampStr);
+                return onError(exchange, "Invalid timestamp format", HttpStatus.UNAUTHORIZED);
+            }
+
+            String internalTokenSecret = env.getProperty("token.secret-internal");
+            long expirationMs = Long.parseLong(env.getProperty("token.expiration_time", "30000"));
+
+            if (Math.abs(now - timestamp) > expirationMs) {
+                log.warn("Expired token: now={}, timestamp={}, allowed={}", now, timestamp, expirationMs);
+                return onError(exchange, "Expired token", HttpStatus.UNAUTHORIZED);
+            }
+
+            String expectedSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, internalTokenSecret)
+                    .hmacHex(timestampStr);
+
+            if (!MessageDigest.isEqual(signature.getBytes(), expectedSignature.getBytes())) {
+                log.warn("Invalid signature: expected={}, provided={}", expectedSignature, signature);
+                return onError(exchange, "Invalid signature", HttpStatus.UNAUTHORIZED);
+            }
+
+            return chain.filter(exchange);
+        };
+    }
+
+    private void logPreFilter(InternalAuthorizationHeaderFilter.Config config, ServerHttpRequest request) {
+        if (config.isPreLogger()) {
+            log.info("Internal Auth Filter Pre-Logger: BaseMessage: {}, Request ID: {}", config.getBaseMessage(), request.getId());
+        }
+    }
+
+    private Mono<Void> onError(ServerWebExchange exchange, String message, HttpStatus status) {
+        log.error("[InternalAuthorizationHeaderFilter] {}", message);
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(status);
+        return response.setComplete();
+    }
+
+    @Data
+    public static class Config {
+        private String baseMessage;
+        private boolean preLogger;
+    }
+}

--- a/CARING-Back-Gateway/src/main/resources/application.yml
+++ b/CARING-Back-Gateway/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
             baseMessage: Spring Cloud Gateway GlobalFilter
             preLogger: true
             postLogger: true
+            addGateWaySignature: true
       routes:
         # === USER SERVICE ===
         - id: user-service-common
@@ -33,6 +34,7 @@ spring:
           filters:
             - RemoveRequestHeader=Cookie
             - RewritePath=/user-service/(?<segment>.*), /${segment}
+            - InternalAuthorizationHeaderFilter
 
         - id: user-service-access
           uri: lb://USER-SERVICE

--- a/CARING-Back-Manager/build.gradle
+++ b/CARING-Back-Manager/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//DatabaseCleanUp
 	implementation group: 'com.google.guava', name: 'guava', version: '12.0'
+	//HMAC, Base64 encryption Util
+	implementation 'commons-codec:commons-codec:1.19.0'
 
 
 	compileOnly 'org.projectlombok:lombok'

--- a/CARING-Back-Manager/src/main/java/com/caring/manager_service/common/config/FeignInterceptorConfig.java
+++ b/CARING-Back-Manager/src/main/java/com/caring/manager_service/common/config/FeignInterceptorConfig.java
@@ -1,0 +1,37 @@
+package com.caring.manager_service.common.config;
+
+import feign.RequestInterceptor;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class FeignInterceptorConfig {
+
+    private final Environment env;
+
+    public FeignInterceptorConfig(Environment env) {
+        this.env = env;
+    }
+
+    @Bean
+    public RequestInterceptor internalAuthHeaderInjector() {
+        return template -> {
+            long timestamp = System.currentTimeMillis();
+            String timestampStr = String.valueOf(timestamp);
+
+            String secret = env.getProperty("token.secret-internal");
+            if (secret == null) {
+                throw new IllegalStateException("Missing property: token.secret-internal");
+            }
+
+            String signature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, secret)
+                    .hmacHex(timestampStr);
+
+            template.header("X-Internal-Timestamp", timestampStr);
+            template.header("X-Internal-Signature", signature);
+        };
+    }
+}

--- a/CARING-Back-User/src/main/java/com/caring/user_service/common/config/SecurityConfig.java
+++ b/CARING-Back-User/src/main/java/com/caring/user_service/common/config/SecurityConfig.java
@@ -1,10 +1,13 @@
 package com.caring.user_service.common.config;
 
-import com.caring.user_service.common.service.MicroServiceIpResolver;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,7 +29,7 @@ import static org.springframework.security.web.util.matcher.AntPathRequestMatche
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final MicroServiceIpResolver microServiceIpResolver;
+    private final Environment env;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -63,18 +66,14 @@ public class SecurityConfig {
                                     "/error", "/images/**").permitAll()
                             .requestMatchers(permitAllRequest()).permitAll()
                             .requestMatchers(additionalSwaggerRequests()).permitAll()
-                            .anyRequest().access((authentication, request) -> {
-                                String clientIp = request.getRequest().getRemoteHost();
-                                String gatewayIp = microServiceIpResolver.resolveGatewayIp();
-                                log.info("client ip is = {} gateway ip is = {}", clientIp, gatewayIp);
-                                boolean isAllowed = clientIp.equals(gatewayIp);
-                                // TODO: 보안 설정에서 localhost(127.0.0.1) 허용은 개발 환경에만 적용해야함
-                                if(clientIp.equals("127.0.0.1")) {
-                                    isAllowed = true;
-                                }
-
-                                return new AuthorizationDecision(isAllowed);
-                            });
+                            .requestMatchers(internalRequests()).access((authentication, request) ->
+                                    verifyHmacAuthorization(request.getRequest(), "X-Internal-Timestamp",
+                                            "X-Internal-Signature", "token.secret-internal")
+                            )
+                            .anyRequest().access((authentication, request) ->
+                                    verifyHmacAuthorization(request.getRequest(), "X-Gateway-Timestamp",
+                                            "X-Gateway-Signature", "token.secret-gateway")
+                            );
                 });
     }
 
@@ -101,13 +100,45 @@ public class SecurityConfig {
         return requestMatchers.toArray(RequestMatcher[]::new);
     }
 
-//    private RequestMatcher[] authRelatedEndpoints() {
-//        List<RequestMatcher> requestMatchers = List.of(
-//                antMatcher("/v1/api/users"),
-//                antMatcher("/v1/api/shelters/**"),
-//                antMatcher(HttpMethod.GET, "/v1/api/managers/submissions"),
-//                antMatcher(HttpMethod.POST, "/v1/api/managers/submissions/{uuid}/permission")
-//        );
-//        return requestMatchers.toArray(RequestMatcher[]::new);
-//    }
+    private RequestMatcher[] internalRequests() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/internal/**")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+
+    private AuthorizationDecision verifyHmacAuthorization(HttpServletRequest request, String timestampHeader, String signatureHeader, String secretKeyName) {
+        String timestamp = request.getHeader(timestampHeader);
+        String signature = request.getHeader(signatureHeader);
+
+        if (timestamp == null || signature == null) {
+            log.warn("Missing header(s): [{}]={}, [{}]={}", timestampHeader, timestamp, signatureHeader, signature);
+            return new AuthorizationDecision(false);
+        }
+
+        String secret = env.getProperty(secretKeyName);
+        if (secret == null) {
+            log.error("Secret not configured for key: {}", secretKeyName);
+            return new AuthorizationDecision(false);
+        }
+
+        //TODO: 개발용 로그이기에 나중에 정식 배포시 삭제
+        log.info("{} is {}", signatureHeader, signature);
+        String expectedSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, secret).hmacHex(timestamp);
+        boolean isValid = expectedSignature.equals(signature);
+
+        try {
+            long sentTime = Long.parseLong(timestamp);
+            long now = System.currentTimeMillis();
+            if (Math.abs(now - sentTime) > 5 * 60 * 1000) {
+                log.warn("Expired HMAC signature: sent={}, now={}", sentTime, now);
+                isValid = false;
+            }
+        } catch (NumberFormatException e) {
+            log.warn("Invalid timestamp format: {}", timestamp);
+            isValid = false;
+        }
+
+        return new AuthorizationDecision(isValid);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- #11 

## 🐛 그동안의 문제점
<img width="1067" height="520" alt="image" src="https://github.com/user-attachments/assets/e553dde8-cbea-433d-b26e-256ee65a9329" />

- 그동안 사용했던 스프링 서큐리티는 Gateway IP와 API를 호출한 클라이언트의 IP를 비교해 같다면 체인을 통과하는 구조입니다.   
- 그러나 이 방식은 다음과 같은 문제점을 갖고 있습니다:   
  - 단일 Gateway IP를 고정적으로 신뢰하기 때문에, 실제 배포 환경에서 Gateway가 여러 인스턴스로 구성된 경우 IP가 달라질 수 있어 오작동 가능성이 있습니다.  
  - getRemoteHost()는 DNS 이름을 반환하는 경우도 있어, 정확한 IP 매칭이 되지 않는 문제가 있습니다.   
  - localhost(127.0.0.1) 등 개발환경 예외 처리가 보안상 위험 요소가 될 수 있으며, 실서버에서 적용 시 실수로 열려 있는 경우 우회 가능성이 생깁니다.  
  - IP는 손쉽게 조작될 수 있기 때문에, 보안 수단으로는 충분하지 않습니다.
  - 또한 서비스끼리 내부 통신에서는 해당 체인이 정상 작동하지 않습니다.

## #️⃣ 해결 방법 : 헤더 기반 서명 검증 방식 도입  
<img width="565" height="417" alt="Untitled (1)" src="https://github.com/user-attachments/assets/6b089a4e-f450-4dc9-af16-285b7a6e69a7" />   

- Gateway가 요청 시점에 X-Gateway-Timestamp와 X-Gateway-Signature를 자동으로 부착함.
- 각 서비스에서는 스프링 서큐리티를 통해서 해당 서명을 secret 기반으로 검증하여 Gateway에서 유입된 요청인지 확인
- IP에 의존하지 않고, Gateway가 보낸 요청이라는 것을 명확히 증명할 수 있는 구조로 개선하였습니다.
- 서비스 내부 통신의 경우엔 X-Internal-Timestamp와 X-Internal-Signature를 도입하여 게이트 웨이와 다른 토큰 값으로 HMAC을 검증합니다.

## 동작 확인
- Access API의 경우엔 헤더의 유무와 관련 없이 작동되고, 필터가 작동하지 않습니다.
- JWT 검증이 필요한 Auth API의 경우엔 Header를 검증합니다. (따라서 게이트웨이 접근이 아닌, 직접 서비스에 요청시 헤더가 없으면 401 인증 에러가 발생합니다.)
- 현재 Signature 헤더 값을 로그로 표시하여 확인하기 쉽게 하였습니다. 실제 정식 배포시엔 뺄 예정입니다!

1. Gateway -> User Service Auth API
<img width="933" height="227" alt="image" src="https://github.com/user-attachments/assets/0af0774f-7c71-4a21-9874-a1360c141567" />
<img width="808" height="182" alt="image" src="https://github.com/user-attachments/assets/d3dcc5d8-7604-43c3-8f63-d59659bb3338" />

2. Gateway -> Manager Service Auth API
<img width="912" height="530" alt="image" src="https://github.com/user-attachments/assets/f6fc37e4-7c03-44ce-a8e2-c449f6335e81" />
<img width="671" height="103" alt="image" src="https://github.com/user-attachments/assets/a71e7481-eca4-4aad-86f8-0ea95c86dfe8" />

3. Gateway -> Manager Service Auth API -> User Internal API
<img width="932" height="636" alt="image" src="https://github.com/user-attachments/assets/6a22e4cd-60d2-4182-8e55-39300001fe09" />
- manager service에서는 gateway에서 넘어왔기에 X-Gateway를 확인합니다.
<img width="722" height="112" alt="image" src="https://github.com/user-attachments/assets/f91559a0-bb39-4f2d-b201-9c73f7938b7e" />
- user service에서는 manager service에서 넘어왔기에 X-Internal을 확인합니다.
<img width="611" height="100" alt="image" src="https://github.com/user-attachments/assets/5d160612-e09c-4c60-87d1-c40b5cd9ac66" />

## 💬 리뷰 요구사항(선택)

- 지금은 동일한 비밀 키 사용하기에, 어떤 이름의 서비스인지 구체적으로 알기 어렵습니다. 정한님이 저번에 어떤 서비스까지 알 수 있으면 좋을 거 같다 하셨는데, 나중에 더 나은 방법이나 관리 방법이 있다면 의견 부탁드립니다!
- 각 서비스의 스프링 시큐리티에 검증이 중복되는 부분이 많아, 코드를 재사용하기 위해 분리하였습니다! 

```java
private AuthorizationDecision verifyHmacAuthorization(HttpServletRequest request, String timestampHeader, String signatureHeader, String secretKeyName) {
        String timestamp = request.getHeader(timestampHeader);
        String signature = request.getHeader(signatureHeader);

        if (timestamp == null || signature == null) {
            log.warn("Missing header(s): [{}]={}, [{}]={}", timestampHeader, timestamp, signatureHeader, signature);
            return new AuthorizationDecision(false);
        }

        String secret = env.getProperty(secretKeyName);
        if (secret == null) {
            log.error("Secret not configured for key: {}", secretKeyName);
            return new AuthorizationDecision(false);
        }

        //TODO: 개발용 로그이기에 나중에 정식 배포시 삭제
        log.info("{} is {}", signatureHeader, signature);
        String expectedSignature = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, secret).hmacHex(timestamp);
        boolean isValid = expectedSignature.equals(signature);

        try {
            long sentTime = Long.parseLong(timestamp);
            long now = System.currentTimeMillis();
            if (Math.abs(now - sentTime) > 5 * 60 * 1000) {
                log.warn("Expired HMAC signature: sent={}, now={}", sentTime, now);
                isValid = false;
            }
        } catch (NumberFormatException e) {
            log.warn("Invalid timestamp format: {}", timestamp);
            isValid = false;
        }

        return new AuthorizationDecision(isValid);
    }
```



